### PR TITLE
Added Docker way of running `klassify`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM alpine:latest
+
+RUN apk add --update python py-pip redis ca-certificates
+
+RUN pip install klassify
+RUN python -c 'import nltk; nltk.download("stopwords")'
+
+EXPOSE 8888

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ There are many use cases of document classifiers in real world:
 ### Installing
 
     sudo pip install klassify
-    
+
 
 If you don't have an nltk corpus, you'll need to run this:
 
-    python -c 'import nltk; nltk.download("stopwords")' 
+    python -c 'import nltk; nltk.download("stopwords")'
 
 You'll also need `redis` installed, check if you have it installed by running this command:
 
@@ -60,3 +60,8 @@ Command line options:
   --redis-port                     redis port (default 6379)
 ```
 
+### Installing using Docker
+
+*Note:* This requires installation of both Docker and docker-compose
+
+    docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "2"
+
+services:
+  klassify:
+    build: .
+    ports:
+      - "8888:8888"
+    links:
+      - redis
+    command: python -m klassify --redis-host=redis
+
+  redis:
+    image: redis:alpine
+    ports: ["6379"]


### PR DESCRIPTION
No need to install redis now, installation is just `docker-compose up` (if you already have docker and docker-compose installed).

It creates two docker containers, one with the webapp and another for redis, both connected so that the webapp can use the redis container to save data.

Also updated README.md with instructions
